### PR TITLE
[fix] 독서모임 게시글 조회API 반환값에 댓글 갯수 추가

### DIFF
--- a/src/main/java/com/umc/server/converter/ClubPostConverter.java
+++ b/src/main/java/com/umc/server/converter/ClubPostConverter.java
@@ -42,6 +42,7 @@ public class ClubPostConverter {
                     .title(post.getTitle())
                     .nickname(post.getMember().getNickname())
                     .context(post.getContext())
+                    .commentCount(post.getClubPostCommentList().size())
                     .likeCount(post.getClubPostLikeList().size())
                     .createAt(post.getCreatedAt())
                     .updateAt(post.getUpdatedAt())

--- a/src/main/java/com/umc/server/web/dto/response/ClubPostResponseDTO.java
+++ b/src/main/java/com/umc/server/web/dto/response/ClubPostResponseDTO.java
@@ -32,6 +32,8 @@ public class ClubPostResponseDTO {
 
         String context;
 
+        Integer commentCount;
+
         Integer likeCount;
 
         LocalDateTime createAt;


### PR DESCRIPTION
✔️ 제목: [feature/reafactor/fix] 한 일(기능명)

✔️ please merge in Squash & Merge!

<br/>

## ⭐Related Issues
- closes #163 

<br/>

## 📝작업 내용
- 독서모임 게시글 조회API 반환값에 댓글 갯수 추가


<br/>

## 참고사항 & 기타
- 코드 리뷰가 필요한 부분이 있다면 적어주세요


<br/>

- [ ] checked assignees
- [ ] checked labels
